### PR TITLE
[improve][broker] Enable Consumer Throttling and Accurate Unacknowledged Message Tracking for Exclusive and Failover Subscriptions

### DIFF
--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/Consumer.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/Consumer.java
@@ -585,10 +585,7 @@ public class Consumer {
                 ackedCount = getAckedCountForBatchIndexLevelEnabled(position, batchSize, ackSets, ackOwnerConsumer);
                 if (isTransactionEnabled()) {
                     //sync the batch position bit set point, in order to delete the position in pending acks
-                    if (Subscription.isIndividualAckMode(subType)) {
-                        ((PersistentSubscription) subscription)
-                                .syncBatchPositionBitSetForPendingAck(position);
-                    }
+                    ((PersistentSubscription) subscription).syncBatchPositionBitSetForPendingAck(position);
                 }
                 addAndGetUnAckedMsgs(ackOwnerConsumer, -(int) ackedCount);
             } else {
@@ -611,7 +608,7 @@ public class Consumer {
                 .collect(Collectors.toList()), AckType.Individual, properties);
         CompletableFuture<Long> completableFuture = new CompletableFuture<>();
         completableFuture.complete(totalAckCount);
-        if (isTransactionEnabled() && Subscription.isIndividualAckMode(subType)) {
+        if (isTransactionEnabled()) {
             completableFuture.whenComplete((v, e) -> positionsAcked.forEach(positionPair -> {
                 Consumer ackOwnerConsumer = positionPair.getLeft();
                 Position position = positionPair.getRight();
@@ -700,7 +697,7 @@ public class Consumer {
     }
 
     private long getAckedCountForMsgIdNoAckSets(int batchSize, Position position, Consumer consumer) {
-        if (isAcknowledgmentAtBatchIndexLevelEnabled && Subscription.isIndividualAckMode(subType)) {
+        if (isAcknowledgmentAtBatchIndexLevelEnabled) {
             long[] cursorAckSet = getCursorAckSet(position);
             if (cursorAckSet != null) {
                 return getAckedCountForBatchIndexLevelEnabled(position, batchSize, EMPTY_ACK_SET, consumer);
@@ -712,7 +709,7 @@ public class Consumer {
     private long getAckedCountForBatchIndexLevelEnabled(Position position, int batchSize, long[] ackSets,
                                                         Consumer consumer) {
         long ackedCount = 0;
-        if (isAcknowledgmentAtBatchIndexLevelEnabled && Subscription.isIndividualAckMode(subType)
+        if (isAcknowledgmentAtBatchIndexLevelEnabled
                 && consumer.getPendingAcks().contains(position.getLedgerId(), position.getEntryId())) {
             long[] cursorAckSet = getCursorAckSet(position);
             if (cursorAckSet != null) {

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/Consumer.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/Consumer.java
@@ -448,8 +448,8 @@ public class Consumer {
     }
 
     private void incrementUnackedMessages(int unackedMessages) {
-        if (Subscription.isIndividualAckMode(subType)
-                && addAndGetUnAckedMsgs(this, unackedMessages) >= getMaxUnackedMessages()
+        if (addAndGetUnAckedMsgs(this, unackedMessages) >= getMaxUnackedMessages()
+                && Subscription.isIndividualAckMode(subType)
                 && getMaxUnackedMessages() > 0) {
             blockedConsumerOnUnackedMsgs = true;
         }
@@ -593,10 +593,9 @@ public class Consumer {
             } else {
                 position = PositionFactory.create(msgId.getLedgerId(), msgId.getEntryId());
                 ackedCount = getAckedCountForMsgIdNoAckSets(batchSize, position, ackOwnerConsumer);
-                if (checkCanRemovePendingAcksAndHandle(ackOwnerConsumer, position, msgId)) {
-                    addAndGetUnAckedMsgs(ackOwnerConsumer, -(int) ackedCount);
-                    updateBlockedConsumerOnUnackedMsgs(ackOwnerConsumer);
-                }
+                checkCanRemovePendingAcksAndHandle(ackOwnerConsumer, position, msgId);
+                addAndGetUnAckedMsgs(ackOwnerConsumer, -(int) ackedCount);
+                updateBlockedConsumerOnUnackedMsgs(ackOwnerConsumer);
             }
 
             positionsAcked.add(Pair.of(ackOwnerConsumer, position));
@@ -1185,7 +1184,7 @@ public class Consumer {
 
     private int addAndGetUnAckedMsgs(Consumer consumer, int ackedMessages) {
         int unackedMsgs = 0;
-        if (isPersistentTopic && Subscription.isIndividualAckMode(subType)) {
+        if (isPersistentTopic) {
             subscription.addUnAckedMessages(ackedMessages);
             unackedMsgs = UNACKED_MESSAGES_UPDATER.addAndGet(consumer, ackedMessages);
         }

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/Consumer.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/Consumer.java
@@ -440,8 +440,8 @@ public class Consumer {
     }
 
     private void incrementUnackedMessages(int unackedMessages) {
-        if (addAndGetUnAckedMsgs(this, unackedMessages) >= getMaxUnackedMessages()
-                && getMaxUnackedMessages() > 0) {
+        int unackedMsgs = addAndGetUnAckedMsgs(this, unackedMessages);
+        if (unackedMsgs >= getMaxUnackedMessages() && getMaxUnackedMessages() > 0) {
             blockedConsumerOnUnackedMsgs = true;
         }
     }

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/Consumer.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/Consumer.java
@@ -142,7 +142,7 @@ public class Consumer {
      * avgMessagesPerEntry = avgMessagePerEntry * avgPercent + (1 - avgPercent) * new Value.
      */
     private final AtomicDouble avgMessagesPerEntry = new AtomicDouble(0);
-    private static final long [] EMPTY_ACK_SET = new long[0];
+    private static final long[] EMPTY_ACK_SET = new long[0];
 
     private static final double avgPercent = 0.9;
     private boolean preciseDispatcherFlowControl;
@@ -233,13 +233,7 @@ public class Consumer {
         stats.setClientVersion(cnx.getClientVersion());
         stats.metadata = this.metadata;
 
-        if (Subscription.isIndividualAckMode(subType)) {
-            this.pendingAcks = new PendingAcksMap(this, this::getPendingAcksAddHandler,
-                    this::getPendingAcksRemoveHandler);
-        } else {
-            // We don't need to keep track of pending acks if the subscription is not shared
-            this.pendingAcks = null;
-        }
+        this.pendingAcks = new PendingAcksMap(this, this::getPendingAcksAddHandler, this::getPendingAcksRemoveHandler);
 
         this.clientAddress = cnx.clientSourceAddress();
         this.consumerEpoch = consumerEpoch;
@@ -299,7 +293,7 @@ public class Consumer {
     void notifyActiveConsumerChange(Consumer activeConsumer) {
         if (log.isDebugEnabled()) {
             log.debug("notify consumer {} - that [{}] for subscription {} has new active consumer : {}",
-                consumerId, topicName, subscription.getName(), activeConsumer);
+                    consumerId, topicName, subscription.getName(), activeConsumer);
         }
         cnx.getCommandSender().sendActiveConsumerChange(consumerId, this == activeConsumer);
     }
@@ -364,45 +358,43 @@ public class Consumer {
                 // Note
                 // Must ensure that the message is written to the pendingAcks before sent is first,
                 // because this consumer is possible to disconnect at this time.
-                if (pendingAcks != null) {
-                    int batchSize = batchSizes.getBatchSize(i);
-                    int stickyKeyHash;
-                    if (stickyKeyHashes == null) {
-                        if (entry instanceof EntryAndMetadata entryAndMetadata) {
-                            stickyKeyHash = entryAndMetadata.getCachedStickyKeyHash();
-                        } else {
-                            stickyKeyHash = STICKY_KEY_HASH_NOT_SET;
-                        }
+                int batchSize = batchSizes.getBatchSize(i);
+                int stickyKeyHash;
+                if (stickyKeyHashes == null) {
+                    if (entry instanceof EntryAndMetadata entryAndMetadata) {
+                        stickyKeyHash = entryAndMetadata.getCachedStickyKeyHash();
                     } else {
-                        stickyKeyHash = stickyKeyHashes.get(i);
+                        stickyKeyHash = STICKY_KEY_HASH_NOT_SET;
                     }
-                    boolean sendingAllowed =
-                            pendingAcks.addPendingAckIfAllowed(entry.getLedgerId(), entry.getEntryId(), batchSize,
-                                    stickyKeyHash);
-                    if (!sendingAllowed) {
-                        // sending isn't allowed when pending acks doesn't accept adding the entry
-                        // this happens when Key_Shared draining hashes contains the stickyKeyHash
-                        // because of race conditions, it might be resolved at the time of sending
-                        totalEntries--;
-                        entries.set(i, null);
-                        entry.release();
-                        if (log.isDebugEnabled()) {
-                            log.debug("[{}-{}] Skipping sending of {}:{} ledger entry with batchSize of {} since adding"
-                                            + " to pending acks failed in broker.service.Consumer for consumerId: {}",
-                                    topicName, subscription, entry.getLedgerId(), entry.getEntryId(), batchSize,
-                                    consumerId);
-                        }
-                    } else {
-                        long[] ackSet = batchIndexesAcks == null ? null : batchIndexesAcks.getAckSet(i);
-                        if (ackSet != null) {
-                            unackedMessages -= (batchSize - BitSet.valueOf(ackSet).cardinality());
-                        }
-                        if (log.isDebugEnabled()) {
-                            log.debug("[{}-{}] Added {}:{} ledger entry with batchSize of {} to pendingAcks in"
-                                            + " broker.service.Consumer for consumerId: {}",
-                                    topicName, subscription, entry.getLedgerId(), entry.getEntryId(), batchSize,
-                                    consumerId);
-                        }
+                } else {
+                    stickyKeyHash = stickyKeyHashes.get(i);
+                }
+                boolean sendingAllowed =
+                        pendingAcks.addPendingAckIfAllowed(entry.getLedgerId(), entry.getEntryId(), batchSize,
+                                stickyKeyHash);
+                if (!sendingAllowed) {
+                    // sending isn't allowed when pending acks doesn't accept adding the entry
+                    // this happens when Key_Shared draining hashes contains the stickyKeyHash
+                    // because of race conditions, it might be resolved at the time of sending
+                    totalEntries--;
+                    entries.set(i, null);
+                    entry.release();
+                    if (log.isDebugEnabled()) {
+                        log.debug("[{}-{}] Skipping sending of {}:{} ledger entry with batchSize of {} since adding"
+                                        + " to pending acks failed in broker.service.Consumer for consumerId: {}",
+                                topicName, subscription, entry.getLedgerId(), entry.getEntryId(), batchSize,
+                                consumerId);
+                    }
+                } else {
+                    long[] ackSet = batchIndexesAcks == null ? null : batchIndexesAcks.getAckSet(i);
+                    if (ackSet != null) {
+                        unackedMessages -= (batchSize - BitSet.valueOf(ackSet).cardinality());
+                    }
+                    if (log.isDebugEnabled()) {
+                        log.debug("[{}-{}] Added {}:{} ledger entry with batchSize of {} to pendingAcks in"
+                                        + " broker.service.Consumer for consumerId: {}",
+                                topicName, subscription, entry.getLedgerId(), entry.getEntryId(), batchSize,
+                                consumerId);
                     }
                 }
             }
@@ -420,10 +412,10 @@ public class Consumer {
         // reduce permit and increment unackedMsg count with total number of messages in batch-msgs
         int ackedCount = batchIndexesAcks == null ? 0 : batchIndexesAcks.getTotalAckedIndexCount();
         MESSAGE_PERMITS_UPDATER.addAndGet(this, ackedCount - totalMessages);
-        if (log.isDebugEnabled()){
+        if (log.isDebugEnabled()) {
             log.debug("[{}-{}] Added {} minus {} messages to MESSAGE_PERMITS_UPDATER in broker.service.Consumer"
                             + " for consumerId: {}; avgMessagesPerEntry is {}",
-                   topicName, subscription, ackedCount, totalMessages, consumerId, avgMessagesPerEntry.get());
+                    topicName, subscription, ackedCount, totalMessages, consumerId, avgMessagesPerEntry.get());
         }
         incrementUnackedMessages(unackedMessages);
         Future<Void> writeAndFlushPromise =
@@ -439,7 +431,7 @@ public class Consumer {
             } else {
                 if (log.isDebugEnabled()) {
                     log.debug("[{}-{}] Sent messages to client fail by IO exception[{}], close the connection"
-                                    + " immediately. Consumer: {}",  topicName, subscription,
+                                    + " immediately. Consumer: {}", topicName, subscription,
                             status.cause() == null ? "" : status.cause().getMessage(), this.toString());
                 }
             }
@@ -448,9 +440,7 @@ public class Consumer {
     }
 
     private void incrementUnackedMessages(int unackedMessages) {
-        int updatedUnackedMessages = addAndGetUnAckedMsgs(this, unackedMessages);
-        if (updatedUnackedMessages >= getMaxUnackedMessages()
-                && Subscription.isIndividualAckMode(subType)
+        if (addAndGetUnAckedMsgs(this, unackedMessages) >= getMaxUnackedMessages()
                 && getMaxUnackedMessages() > 0) {
             blockedConsumerOnUnackedMsgs = true;
         }
@@ -511,7 +501,7 @@ public class Consumer {
         Map<String, Long> properties = Collections.emptyMap();
         if (ack.getPropertiesCount() > 0) {
             properties = ack.getPropertiesList().stream()
-                .collect(Collectors.toMap(KeyLongValue::getKey, KeyLongValue::getValue));
+                    .collect(Collectors.toMap(KeyLongValue::getKey, KeyLongValue::getValue));
         }
 
         if (ack.getAckType() == AckType.Cumulative) {
@@ -548,6 +538,16 @@ public class Consumer {
                 subscription.acknowledgeMessage(positionsAcked, AckType.Cumulative, properties);
                 future = CompletableFuture.completedFuture(1L);
             }
+            future.thenRun(() -> {
+                ObjectIntPair<Consumer> ackOwnerConsumerAndBatchSize =
+                        getAckOwnerConsumerAndBatchSize(msgId.getLedgerId(), msgId.getEntryId());
+                Consumer ackOwnerConsumer = ackOwnerConsumerAndBatchSize.left();
+                int ackedCount = removePendingAcksUpToPosition(ackOwnerConsumer, position);
+                if (ackedCount > 0) {
+                    addAndGetUnAckedMsgs(ackOwnerConsumer, -(int) ackedCount);
+                    updateBlockedConsumerOnUnackedMsgs(ackOwnerConsumer);
+                }
+            });
         } else {
             if (ack.hasTxnidLeastBits() && ack.hasTxnidMostBits()) {
                 future = individualAckWithTransaction(ack);
@@ -597,8 +597,6 @@ public class Consumer {
                 if (checkCanRemovePendingAcksAndHandle(ackOwnerConsumer, position, msgId)) {
                     addAndGetUnAckedMsgs(ackOwnerConsumer, -(int) ackedCount);
                     updateBlockedConsumerOnUnackedMsgs(ackOwnerConsumer);
-                } else if (Subscription.isCumulativeAckMode(subType)) {
-                    addAndGetUnAckedMsgs(ackOwnerConsumer, -(int) ackedCount);
                 }
             }
 
@@ -687,19 +685,17 @@ public class Consumer {
 
         CompletableFuture<Void> completableFuture = transactionIndividualAcknowledge(ack.getTxnidMostBits(),
                 ack.getTxnidLeastBits(), positionsAcked.stream().map(Pair::getRight).collect(Collectors.toList()));
-        if (Subscription.isIndividualAckMode(subType)) {
-            completableFuture.whenComplete((v, e) ->
-                    positionsAcked.forEach(positionPair -> {
-                        Consumer ackOwnerConsumer = positionPair.getLeft();
-                        MutablePair<Position, Integer> positionLongMutablePair = positionPair.getRight();
-                        if (AckSetStateUtil.hasAckSet(positionLongMutablePair.getLeft())) {
-                            if (((PersistentSubscription) subscription)
-                                    .checkIsCanDeleteConsumerPendingAck(positionLongMutablePair.left)) {
-                                removePendingAcks(ackOwnerConsumer, positionLongMutablePair.left);
-                            }
+        completableFuture.whenComplete((v, e) ->
+                positionsAcked.forEach(positionPair -> {
+                    Consumer ackOwnerConsumer = positionPair.getLeft();
+                    MutablePair<Position, Integer> positionLongMutablePair = positionPair.getRight();
+                    if (AckSetStateUtil.hasAckSet(positionLongMutablePair.getLeft())) {
+                        if (((PersistentSubscription) subscription)
+                                .checkIsCanDeleteConsumerPendingAck(positionLongMutablePair.left)) {
+                            removePendingAcks(ackOwnerConsumer, positionLongMutablePair.left);
                         }
-                    }));
-        }
+                    }
+                }));
         return completableFuture.thenApply(__ -> totalAckCount.sum());
     }
 
@@ -717,7 +713,7 @@ public class Consumer {
                                                         Consumer consumer) {
         long ackedCount = 0;
         if (isAcknowledgmentAtBatchIndexLevelEnabled && Subscription.isIndividualAckMode(subType)
-            && consumer.getPendingAcks().contains(position.getLedgerId(), position.getEntryId())) {
+                && consumer.getPendingAcks().contains(position.getLedgerId(), position.getEntryId())) {
             long[] cursorAckSet = getCursorAckSet(position);
             if (cursorAckSet != null) {
                 BitSetRecyclable cursorBitSet = BitSetRecyclable.create().resetWords(cursorAckSet);
@@ -764,7 +760,7 @@ public class Consumer {
 
     private boolean checkCanRemovePendingAcksAndHandle(Consumer ackOwnedConsumer,
                                                        Position position, MessageIdData msgId) {
-        if (Subscription.isIndividualAckMode(subType) && msgId.getAckSetsCount() == 0) {
+        if (msgId.getAckSetsCount() == 0) {
             return removePendingAcks(ackOwnedConsumer, position);
         }
         return false;
@@ -774,22 +770,20 @@ public class Consumer {
      * Retrieves the acknowledgment owner consumer and batch size for the specified ledgerId and entryId.
      *
      * @param ledgerId The ID of the ledger.
-     * @param entryId The ID of the entry.
+     * @param entryId  The ID of the entry.
      * @return Pair<Consumer, BatchSize>
      */
     private ObjectIntPair<Consumer> getAckOwnerConsumerAndBatchSize(long ledgerId, long entryId) {
-        if (Subscription.isIndividualAckMode(subType)) {
-            IntIntPair pendingAck = getPendingAcks().get(ledgerId, entryId);
-            if (pendingAck != null) {
-                return ObjectIntPair.of(this, pendingAck.leftInt());
-            } else {
-                // If there are more consumers, this step will consume more CPU, and it should be optimized later.
-                for (Consumer consumer : subscription.getConsumers()) {
-                    if (consumer != this) {
-                        pendingAck = consumer.getPendingAcks().get(ledgerId, entryId);
-                        if (pendingAck != null) {
-                            return ObjectIntPair.of(consumer, pendingAck.leftInt());
-                        }
+        IntIntPair pendingAck = getPendingAcks().get(ledgerId, entryId);
+        if (pendingAck != null) {
+            return ObjectIntPair.of(this, pendingAck.leftInt());
+        } else {
+            // If there are more consumers, this step will consume more CPU, and it should be optimized later.
+            for (Consumer consumer : subscription.getConsumers()) {
+                if (consumer != this) {
+                    pendingAck = consumer.getPendingAcks().get(ledgerId, entryId);
+                    if (pendingAck != null) {
+                        return ObjectIntPair.of(consumer, pendingAck.leftInt());
                     }
                 }
             }
@@ -871,14 +865,13 @@ public class Consumer {
      * Triggers dispatcher to dispatch {@code blockedPermits} number of messages and adds same number of permits to
      * {@code messagePermits} as it maintains count of actual dispatched message-permits.
      *
-     * @param consumer:
-     *            Consumer whose blockedPermits needs to be dispatched
+     * @param consumer: Consumer whose blockedPermits needs to be dispatched
      */
     void flowConsumerBlockedPermits(Consumer consumer) {
         int additionalNumberOfPermits = PERMITS_RECEIVED_WHILE_CONSUMER_BLOCKED_UPDATER.getAndSet(consumer, 0);
         // add newly flow permits to actual consumer.messagePermits
         MESSAGE_PERMITS_UPDATER.getAndAdd(consumer, additionalNumberOfPermits);
-        if (log.isDebugEnabled()){
+        if (log.isDebugEnabled()) {
             log.debug("[{}-{}] Added {} blocked permits to broker.service.Consumer for consumer {}", topicName,
                     subscription, additionalNumberOfPermits, consumerId);
         }
@@ -930,6 +923,7 @@ public class Consumer {
         }
         return false;
     }
+
     /**
      * Checks if consumer-blocking on unAckedMessages is allowed for below conditions:<br/>
      * a. consumer must have Shared-subscription<br/>
@@ -938,7 +932,7 @@ public class Consumer {
      * @return
      */
     private boolean shouldBlockConsumerOnUnackMsgs() {
-        return Subscription.isIndividualAckMode(subType) && getMaxUnackedMessages() > 0;
+        return getMaxUnackedMessages() > 0;
     }
 
     public void updateRates() {
@@ -1052,7 +1046,7 @@ public class Consumer {
 
     @Override
     public boolean equals(Object obj) {
-        if (this == obj)  {
+        if (this == obj) {
             return true;
         }
         if (obj instanceof Consumer) {
@@ -1070,9 +1064,8 @@ public class Consumer {
     /**
      * first try to remove ack-position from the current_consumer's pendingAcks.
      * if ack-message doesn't present into current_consumer's pendingAcks
-     *  a. try to remove from other connected subscribed consumers (It happens when client
+     * a. try to remove from other connected subscribed consumers (It happens when client
      * tries to acknowledge message through different consumer under the same subscription)
-     *
      *
      * @param position
      */
@@ -1087,6 +1080,15 @@ public class Consumer {
         }
         updateBlockedConsumerOnUnackedMsgs(ackOwnedConsumer);
         return true;
+    }
+
+    private int removePendingAcksUpToPosition(Consumer ackOwnedConsumer, Position position) {
+        PendingAcksMap ownedConsumerPendingAcks = ackOwnedConsumer.getPendingAcks();
+        int removedMessageSize = ownedConsumerPendingAcks.removeAllUpTo(position.getLedgerId(), position.getEntryId());
+        if (log.isDebugEnabled()) {
+            log.debug("[{}-{}] consumer {} received ack {}", topicName, subscription, consumerId, position);
+        }
+        return removedMessageSize;
     }
 
     public void updateBlockedConsumerOnUnackedMsgs(Consumer ackOwnedConsumer) {
@@ -1175,8 +1177,8 @@ public class Consumer {
         if (numberOfBlockedPermits > 0) {
             MESSAGE_PERMITS_UPDATER.getAndAdd(this, numberOfBlockedPermits);
             if (log.isDebugEnabled()) {
-               log.debug("[{}-{}] Added {} blockedPermits to broker.service.Consumer's messagePermits for consumer {}",
-                       topicName, subscription, numberOfBlockedPermits, consumerId);
+                log.debug("[{}-{}] Added {} blockedPermits to broker.service.Consumer's messagePermits for consumer {}",
+                        topicName, subscription, numberOfBlockedPermits, consumerId);
             }
             subscription.consumerFlow(this, numberOfBlockedPermits);
         }

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/Consumer.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/Consumer.java
@@ -593,9 +593,12 @@ public class Consumer {
             } else {
                 position = PositionFactory.create(msgId.getLedgerId(), msgId.getEntryId());
                 ackedCount = getAckedCountForMsgIdNoAckSets(batchSize, position, ackOwnerConsumer);
-                checkCanRemovePendingAcksAndHandle(ackOwnerConsumer, position, msgId);
-                addAndGetUnAckedMsgs(ackOwnerConsumer, -(int) ackedCount);
-                updateBlockedConsumerOnUnackedMsgs(ackOwnerConsumer);
+                if (checkCanRemovePendingAcksAndHandle(ackOwnerConsumer, position, msgId)) {
+                    addAndGetUnAckedMsgs(ackOwnerConsumer, -(int) ackedCount);
+                    updateBlockedConsumerOnUnackedMsgs(ackOwnerConsumer);
+                } else if (Subscription.isCumulativeAckMode(subType)) {
+                    addAndGetUnAckedMsgs(ackOwnerConsumer, -(int) ackedCount);
+                }
             }
 
             positionsAcked.add(Pair.of(ackOwnerConsumer, position));

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/Consumer.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/Consumer.java
@@ -1119,7 +1119,7 @@ public class Consumer {
             log.debug("[{}-{}] consumer {} received redelivery", topicName, subscription, consumerId);
         }
 
-        if (pendingAcks != null) {
+        if (Subscription.isIndividualAckMode(subType)) {
             List<Position> pendingPositions = new ArrayList<>((int) pendingAcks.size());
             MutableInt totalRedeliveryMessages = new MutableInt(0);
             pendingAcks.forEach((ledgerId, entryId, batchSize, stickyKeyHash) -> {
@@ -1139,6 +1139,7 @@ public class Consumer {
 
             subscription.redeliverUnacknowledgedMessages(this, pendingPositions);
         } else {
+            pendingAcks.clear();
             subscription.redeliverUnacknowledgedMessages(this, consumerEpoch);
         }
 

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/Consumer.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/Consumer.java
@@ -448,7 +448,8 @@ public class Consumer {
     }
 
     private void incrementUnackedMessages(int unackedMessages) {
-        if (addAndGetUnAckedMsgs(this, unackedMessages) >= getMaxUnackedMessages()
+        int updatedUnackedMessages = addAndGetUnAckedMsgs(this, unackedMessages);
+        if (updatedUnackedMessages >= getMaxUnackedMessages()
                 && Subscription.isIndividualAckMode(subType)
                 && getMaxUnackedMessages() > 0) {
             blockedConsumerOnUnackedMsgs = true;

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/Consumer.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/Consumer.java
@@ -923,8 +923,7 @@ public class Consumer {
 
     /**
      * Checks if consumer-blocking on unAckedMessages is allowed for below conditions:<br/>
-     * a. consumer must have Shared-subscription<br/>
-     * b. {@link this#getMaxUnackedMessages()} value > 0
+     * {@link this#getMaxUnackedMessages()} value > 0.
      *
      * @return
      */

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/PendingAcksMap.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/PendingAcksMap.java
@@ -330,9 +330,10 @@ public class PendingAcksMap {
      *
      * @param markDeleteLedgerId the ledger ID up to which to remove pending acks
      * @param markDeleteEntryId the entry ID up to which to remove pending acks
+     * @return the sum batchSize of removed pending acks
      */
-    public void removeAllUpTo(long markDeleteLedgerId, long markDeleteEntryId) {
-        internalRemoveAllUpTo(markDeleteLedgerId, markDeleteEntryId, false);
+    public int removeAllUpTo(long markDeleteLedgerId, long markDeleteEntryId) {
+        return internalRemoveAllUpTo(markDeleteLedgerId, markDeleteEntryId, false);
     }
 
     /**
@@ -345,8 +346,9 @@ public class PendingAcksMap {
      * @param markDeleteLedgerId the ledger ID up to which to remove pending acks
      * @param markDeleteEntryId the entry ID up to which to remove pending acks
      * @param useWriteLock true if the method should use a write lock, false otherwise
+     * @return the sum batchSize of removed pending acks
      */
-    private void internalRemoveAllUpTo(long markDeleteLedgerId, long markDeleteEntryId, boolean useWriteLock) {
+    private int internalRemoveAllUpTo(long markDeleteLedgerId, long markDeleteEntryId, boolean useWriteLock) {
         PendingAcksRemoveHandler pendingAcksRemoveHandler = pendingAcksRemoveHandlerSupplier.get();
         // track if the write lock was acquired
         boolean acquiredWriteLock = false;
@@ -354,6 +356,8 @@ public class PendingAcksMap {
         boolean batchStarted = false;
         // track if the method should retry with a write lock
         boolean retryWithWriteLock = false;
+        // the number of removed pending acks
+        int removeCount = 0;
         try {
             if (useWriteLock) {
                 writeLock.lock();
@@ -378,9 +382,10 @@ public class PendingAcksMap {
                 while (entryMapIterator.hasNext()) {
                     Long2ObjectMap.Entry<IntIntPair> intIntPairEntry = entryMapIterator.next();
                     long entryId = intIntPairEntry.getLongKey();
+                    int batchSize = intIntPairEntry.getValue().leftInt();
                     if (!acquiredWriteLock) {
                         retryWithWriteLock = true;
-                        return;
+                        break;
                     }
                     if (pendingAcksRemoveHandler != null) {
                         if (!batchStarted) {
@@ -390,12 +395,16 @@ public class PendingAcksMap {
                         int stickyKeyHash = intIntPairEntry.getValue().rightInt();
                         pendingAcksRemoveHandler.handleRemoving(consumer, ledgerId, entryId, stickyKeyHash, closed);
                     }
+                    removeCount += batchSize;
                     entryMapIterator.remove();
+                }
+                if (retryWithWriteLock) {
+                    break;
                 }
                 if (ledgerMap.isEmpty()) {
                     if (!acquiredWriteLock) {
                         retryWithWriteLock = true;
-                        return;
+                        break;
                     }
                     ledgerMapIterator.remove();
                 }
@@ -409,10 +418,11 @@ public class PendingAcksMap {
             } else {
                 readLock.unlock();
                 if (retryWithWriteLock) {
-                    internalRemoveAllUpTo(markDeleteLedgerId, markDeleteEntryId, true);
+                    removeCount = internalRemoveAllUpTo(markDeleteLedgerId, markDeleteEntryId, true);
                 }
             }
         }
+        return removeCount;
     }
 
     private void handleRemovePendingAck(long ledgerId, long entryId, int stickyKeyHash) {

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/PendingAcksMap.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/PendingAcksMap.java
@@ -41,6 +41,7 @@ import java.util.function.Supplier;
  * running.
  */
 public class PendingAcksMap {
+
     /**
      * Callback interface for handling the addition of pending acknowledgments.
      */
@@ -221,6 +222,15 @@ public class PendingAcksMap {
             } else {
                 processPendingAcks(processor);
             }
+            pendingAcks.clear();
+        } finally {
+            writeLock.unlock();
+        }
+    }
+
+    public void clear() {
+        try {
+            writeLock.lock();
             pendingAcks.clear();
         } finally {
             writeLock.unlock();

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/persistent/PersistentDispatcherSingleActiveConsumer.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/persistent/PersistentDispatcherSingleActiveConsumer.java
@@ -437,8 +437,9 @@ public class PersistentDispatcherSingleActiveConsumer extends AbstractDispatcher
             messagesToRead = Math.min((int) Math.ceil(availablePermits * 1.0 / avgMessagesPerEntry), readBatchSize);
         }
         // We need to ensure that we don't exceed the max unacked messages.
-        if (consumer.getMaxUnackedMessages() > 0) {
-            messagesToRead = Math.min(messagesToRead, consumer.getMaxUnackedMessages() - consumer.getUnackedMessages());
+        int maxUnackedMessages = consumer.getMaxUnackedMessages();
+        if (maxUnackedMessages > 0) {
+            messagesToRead = Math.min(messagesToRead, maxUnackedMessages - consumer.getUnackedMessages());
         }
 
         // throttle only if: (1) cursor is not active (or flag for throttle-nonBacklogConsumer is enabled) bcz

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/persistent/PersistentDispatcherSingleActiveConsumer.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/persistent/PersistentDispatcherSingleActiveConsumer.java
@@ -429,24 +429,16 @@ public class PersistentDispatcherSingleActiveConsumer extends AbstractDispatcher
             availablePermits = 1;
         }
 
-        // fix concurrent flow issue.
-        // For example, consumer send two flow requests at the same time. Both request 5 messages.
-        // But consumer.getMaxUnackedMessages() - consumer.getUnackedMessages()) is 5 at this time,
-        // The first thread will increase the permits to 5, and the second thread will increase the permits to 10,
-        // Finally the first thread will fetch 10 messages at most,
-        // but actually only 5 messages should be fetched at most.
-        // I have met this issue when write unit test MaxUnackedMessagesTest.testMaxUnackedMessagesOnExclusiveConsumer.
-        if (consumer.getMaxUnackedMessages() > 0) {
-            availablePermits = Math.min(consumer.getAvailablePermits(),
-                    consumer.getMaxUnackedMessages() - consumer.getUnackedMessages());
-        }
-
         int messagesToRead = Math.min(availablePermits, readBatchSize);
         long bytesToRead = serviceConfig.getDispatcherMaxReadSizeBytes();
         // if turn of precise dispatcher flow control, adjust the records to read
         if (consumer.isPreciseDispatcherFlowControl()) {
             int avgMessagesPerEntry = Math.max(1, consumer.getAvgMessagesPerEntry());
             messagesToRead = Math.min((int) Math.ceil(availablePermits * 1.0 / avgMessagesPerEntry), readBatchSize);
+        }
+        // We need to ensure that we don't exceed the max unacked messages.
+        if (consumer.getMaxUnackedMessages() > 0) {
+            messagesToRead = Math.min(messagesToRead, consumer.getMaxUnackedMessages() - consumer.getUnackedMessages());
         }
 
         // throttle only if: (1) cursor is not active (or flag for throttle-nonBacklogConsumer is enabled) bcz

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/persistent/PersistentSubscription.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/persistent/PersistentSubscription.java
@@ -1315,7 +1315,9 @@ public class PersistentSubscription extends AbstractSubscription {
         SubType subType = getType();
         subStats.type = getTypeString();
         if (dispatcher instanceof PersistentDispatcherSingleActiveConsumer) {
-            Consumer activeConsumer = ((PersistentDispatcherSingleActiveConsumer) dispatcher).getActiveConsumer();
+            PersistentDispatcherSingleActiveConsumer d = ((PersistentDispatcherSingleActiveConsumer) dispatcher);
+            subStats.unackedMessages = d.getUnackedMessages();
+            Consumer activeConsumer = d.getActiveConsumer();
             if (activeConsumer != null) {
                 subStats.activeConsumerName = activeConsumer.consumerName();
             }

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/BatchMessageTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/BatchMessageTest.java
@@ -1085,18 +1085,14 @@ public class BatchMessageTest extends BrokerTestBase {
                 .getTopic(topic, false).get().get().getSubscription(subscriptionName);
 
         Awaitility.await().untilAsserted(() -> {
-            if (subType == SubscriptionType.Shared) {
-                if (enableBatch) {
-                    if (conf.isAcknowledgmentAtBatchIndexLevelEnabled()) {
-                        assertEquals(persistentSubscription.getConsumers().get(0).getUnackedMessages(), 5 * 1);
-                    } else {
-                        assertEquals(persistentSubscription.getConsumers().get(0).getUnackedMessages(), 5 * 3);
-                    }
+            if (enableBatch) {
+                if (conf.isAcknowledgmentAtBatchIndexLevelEnabled()) {
+                    assertEquals(persistentSubscription.getConsumers().get(0).getUnackedMessages(), 5 * 1);
                 } else {
-                    assertEquals(persistentSubscription.getConsumers().get(0).getUnackedMessages(), messageCount / 2);
+                    assertEquals(persistentSubscription.getConsumers().get(0).getUnackedMessages(), 5 * 3);
                 }
             } else {
-                assertEquals(persistentSubscription.getConsumers().get(0).getUnackedMessages(), 0);
+                assertEquals(persistentSubscription.getConsumers().get(0).getUnackedMessages(), messageCount / 2);
             }
         });
     }

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/persistent/PersistentDispatcherSingleActiveConsumerTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/persistent/PersistentDispatcherSingleActiveConsumerTest.java
@@ -51,6 +51,7 @@ import org.mockito.Mockito;
 import org.testng.Assert;
 import org.testng.annotations.AfterClass;
 import org.testng.annotations.BeforeClass;
+import org.testng.annotations.DataProvider;
 import org.testng.annotations.Test;
 
 @Slf4j
@@ -72,6 +73,14 @@ public class PersistentDispatcherSingleActiveConsumerTest extends ProducerConsum
         pulsar.getPulsarResources().getNamespaceResources().getPartitionedTopicResources()
                 .createPartitionedTopic(SystemTopicNames.TRANSACTION_COORDINATOR_ASSIGN,
                         new PartitionedTopicMetadata(1));
+    }
+
+    @DataProvider(name = "enableBatching")
+    public static Object[][] enableBatching() {
+        return new Object[][]{
+                {true},
+                {false}
+        };
     }
 
     @AfterClass(alwaysRun = true)
@@ -104,7 +113,8 @@ public class PersistentDispatcherSingleActiveConsumerTest extends ProducerConsum
         Mockito.doReturn(topic).when(sub).getTopic();
         // Mock the dispatcher.
         PersistentDispatcherSingleActiveConsumer dispatcher =
-                Mockito.spy(new PersistentDispatcherSingleActiveConsumer(cursor, CommandSubscribe.SubType.Exclusive,0, topic, sub));
+                Mockito.spy(new PersistentDispatcherSingleActiveConsumer(cursor, CommandSubscribe.SubType.Exclusive, 0,
+                        topic, sub));
 
         // Mock a consumer
         Consumer consumer = Mockito.mock(Consumer.class);
@@ -145,15 +155,16 @@ public class PersistentDispatcherSingleActiveConsumerTest extends ProducerConsum
 
         dispatcher.readMoreEntries(consumer);
 
-        // Verify: the readEntriesFailed should be called once and the scheduleReadEntriesWithDelay should not be called.
+        // Verify: the readEntriesFailed should be called once and the scheduleReadEntriesWithDelay should not be
+        // called.
         Assert.assertTrue(callReadEntriesFailed.get() == 1 && callScheduleReadEntriesWithDelayCnt.get() == 0);
 
         // Verify: the topic can be deleted successfully.
         admin.topics().delete(topicName, false);
     }
 
-    @Test
-    public void testUnackedMessages() throws Exception {
+    @Test(dataProvider = "enableBatching")
+    public void testUnackedMessages(boolean enableBatching) throws Exception {
         long timeMillis = System.currentTimeMillis();
         String topicNamePrefix = "testUnackedMessages-" + timeMillis;
         String subscriptionNamePrefix = "testUnackedMessages-sub-" + timeMillis;
@@ -161,89 +172,87 @@ public class PersistentDispatcherSingleActiveConsumerTest extends ProducerConsum
         // we will check unacked messages every 20 messages
         int checkStep = 20;
 
-        for(boolean enableBatching : new boolean[] {false, true}) {
-            for (SubscriptionType subscription : ImmutableList.of(SubscriptionType.Exclusive,
-                    SubscriptionType.Failover)) {
-                String topicName = topicNamePrefix + subscription.name() + "-" + enableBatching;
-                String subscriptionName = subscriptionNamePrefix + subscription.name();
-                @Cleanup
-                org.apache.pulsar.client.api.Consumer<String> consumer = pulsarClient.newConsumer(Schema.STRING)
-                        .topic(topicName).subscriptionName(subscriptionName)
-                        .subscriptionType(subscription)
-                        .receiverQueueSize(totalProducedMessage)
-                        .ackTimeout(1000, TimeUnit.MILLISECONDS)
-                        .negativeAckRedeliveryDelay(0, TimeUnit.SECONDS)
-                        .acknowledgmentGroupTime(0, TimeUnit.SECONDS)
-                        .maxAcknowledgmentGroupSize(1)
-                        .subscribe();
+        for (SubscriptionType subscription : ImmutableList.of(SubscriptionType.Exclusive,
+                SubscriptionType.Failover)) {
+            String topicName = topicNamePrefix + subscription.name() + "-" + enableBatching;
+            String subscriptionName = subscriptionNamePrefix + subscription.name();
+            @Cleanup
+            org.apache.pulsar.client.api.Consumer<String> consumer = pulsarClient.newConsumer(Schema.STRING)
+                    .topic(topicName).subscriptionName(subscriptionName)
+                    .subscriptionType(subscription)
+                    .receiverQueueSize(totalProducedMessage)
+                    .ackTimeout(1000, TimeUnit.MILLISECONDS)
+                    .negativeAckRedeliveryDelay(0, TimeUnit.SECONDS)
+                    .acknowledgmentGroupTime(0, TimeUnit.SECONDS)
+                    .maxAcknowledgmentGroupSize(1)
+                    .subscribe();
 
-                @Cleanup
-                Producer<String> producer =
-                        pulsarClient.newProducer(Schema.STRING).enableBatching(enableBatching).topic(topicName).create();
+            @Cleanup
+            Producer<String> producer =
+                    pulsarClient.newProducer(Schema.STRING).enableBatching(enableBatching).topic(topicName).create();
 
-                for (int i = 0; i < totalProducedMessage; ++i) {
-                    producer.sendAsync(Integer.toString(i));
-                }
-
-                // 1) check unacked message at begin
-                checkUnackedMessage(topicName, subscriptionName, totalProducedMessage);
-
-                // 2) check unacked message every checkStep
-                for (int i = 0; i < totalProducedMessage; ++i) {
-                    Message<String> msg = consumer.receive(1, TimeUnit.SECONDS);
-                    if (Objects.isNull(msg)) {
-                        Assert.fail("Expected message not received");
-                    }
-                    consumer.acknowledge(msg.getMessageId());
-                    if ((i + 1) % checkStep == 0) {
-                        checkUnackedMessage(topicName, subscriptionName, totalProducedMessage - i - 1);
-                    }
-                }
-
-                // 3) check unacked message at end
-                checkUnackedMessage(topicName, subscriptionName, 0);
-
-                // 4) test negative ack
-                for (int i = 0; i < totalProducedMessage; ++i) {
-                    producer.sendAsync(Integer.toString(i));
-                }
-                Message<String> msg = null;
-                checkUnackedMessage(topicName, subscriptionName, totalProducedMessage);
-                for (int i = 0; i < totalProducedMessage; ++i) {
-                    msg = consumer.receive(1, TimeUnit.SECONDS);
-                    if (Objects.isNull(msg)) {
-                        Assert.fail("Expected message not received");
-                    }
-                }
-                consumer.negativeAcknowledge(msg);
-                // sleep for a while to wait for the negative ack to be processed
-                Thread.sleep(1000);
-                TopicStats topicStats = admin.topics().getStats(topicName);
-                assertThat(topicStats.getSubscriptions().get(subscriptionName).getUnackedMessages()).isEqualTo(
-                        totalProducedMessage);
-
-                // 5) test cumulative ack or negative ack mode
-                consumer.acknowledgeCumulative(msg);
-                checkUnackedMessage(topicName, subscriptionName, 0);
-
-                // 6) after cumulation ack, consumer can receive message again
-                for (int i = 0; i < totalProducedMessage; ++i) {
-                    producer.sendAsync(Integer.toString(i));
-                }
-
-                for (int i = 0; i < totalProducedMessage; ++i) {
-                    msg = consumer.receive(5, TimeUnit.SECONDS);
-                    if (Objects.isNull(msg)) {
-                        Assert.fail("Expected message not received");
-                    }
-                }
-                checkUnackedMessage(topicName, subscriptionName, totalProducedMessage);
+            for (int i = 0; i < totalProducedMessage; ++i) {
+                producer.sendAsync(Integer.toString(i));
             }
+
+            // 1) check unacked message at begin
+            checkUnackedMessage(topicName, subscriptionName, totalProducedMessage);
+
+            // 2) check unacked message every checkStep
+            for (int i = 0; i < totalProducedMessage; ++i) {
+                Message<String> msg = consumer.receive(1, TimeUnit.SECONDS);
+                if (Objects.isNull(msg)) {
+                    Assert.fail("Expected message not received");
+                }
+                consumer.acknowledge(msg.getMessageId());
+                if ((i + 1) % checkStep == 0) {
+                    checkUnackedMessage(topicName, subscriptionName, totalProducedMessage - i - 1);
+                }
+            }
+
+            // 3) check unacked message at end
+            checkUnackedMessage(topicName, subscriptionName, 0);
+
+            // 4) test negative ack
+            for (int i = 0; i < totalProducedMessage; ++i) {
+                producer.sendAsync(Integer.toString(i));
+            }
+            Message<String> msg = null;
+            checkUnackedMessage(topicName, subscriptionName, totalProducedMessage);
+            for (int i = 0; i < totalProducedMessage; ++i) {
+                msg = consumer.receive(1, TimeUnit.SECONDS);
+                if (Objects.isNull(msg)) {
+                    Assert.fail("Expected message not received");
+                }
+            }
+            consumer.negativeAcknowledge(msg);
+            // sleep for a while to wait for the negative ack to be processed
+            Thread.sleep(1000);
+            TopicStats topicStats = admin.topics().getStats(topicName);
+            assertThat(topicStats.getSubscriptions().get(subscriptionName).getUnackedMessages()).isEqualTo(
+                    totalProducedMessage);
+
+            // 5) test cumulative ack or negative ack mode
+            consumer.acknowledgeCumulative(msg);
+            checkUnackedMessage(topicName, subscriptionName, 0);
+
+            // 6) after cumulation ack, consumer can receive message again
+            for (int i = 0; i < totalProducedMessage; ++i) {
+                producer.sendAsync(Integer.toString(i));
+            }
+
+            for (int i = 0; i < totalProducedMessage; ++i) {
+                msg = consumer.receive(5, TimeUnit.SECONDS);
+                if (Objects.isNull(msg)) {
+                    Assert.fail("Expected message not received");
+                }
+            }
+            checkUnackedMessage(topicName, subscriptionName, totalProducedMessage);
         }
     }
 
-    @Test
-    public void testUnackedMessagesWithTransaction() throws Exception {
+    @Test(dataProvider = "enableBatching")
+    public void testUnackedMessagesWithTransaction(boolean enableBatching) throws Exception {
         long timeMillis = System.currentTimeMillis();
         String topicNamePrefix = "testUnackedMessagesWithTrn-" + timeMillis;
         String subscriptionNamePrefix = "testUnackedMessagesWithTrn-sub-" + timeMillis;
@@ -257,91 +266,91 @@ public class PersistentDispatcherSingleActiveConsumerTest extends ProducerConsum
                 .statsInterval(0, TimeUnit.SECONDS)
                 .build();
 
-        for (boolean enableBatching: new boolean[] {false, true}) {
-            for (SubscriptionType subscription : ImmutableList.of(SubscriptionType.Exclusive,
-                    SubscriptionType.Failover)) {
-                String inputTopicName = topicNamePrefix + subscription.name() + "-input-" + enableBatching;
-                String outputTopicName = topicNamePrefix + subscription.name() + "-output-"+ enableBatching;
-                String subscriptionName = subscriptionNamePrefix + subscription.name();
-                @Cleanup
-                org.apache.pulsar.client.api.Consumer<String> inputConsumer = pulsarClient.newConsumer(Schema.STRING)
-                        .topic(inputTopicName).subscriptionName(subscriptionName)
-                        .subscriptionType(subscription)
-                        .receiverQueueSize(totalProducedMessage)
-                        .ackTimeout(1000, TimeUnit.MILLISECONDS)
-                        .negativeAckRedeliveryDelay(0, TimeUnit.SECONDS)
-                        .acknowledgmentGroupTime(0, TimeUnit.SECONDS)
-                        .maxAcknowledgmentGroupSize(1)
-                        .subscribe();
-                @Cleanup
-                org.apache.pulsar.client.api.Consumer<String> outputConsumer = pulsarClient.newConsumer(Schema.STRING)
-                        .topic(outputTopicName).subscriptionName(subscriptionName)
-                        .subscriptionType(subscription)
-                        .receiverQueueSize(totalProducedMessage)
-                        .ackTimeout(1000, TimeUnit.MILLISECONDS)
-                        .negativeAckRedeliveryDelay(0, TimeUnit.SECONDS)
-                        .acknowledgmentGroupTime(0, TimeUnit.SECONDS)
-                        .maxAcknowledgmentGroupSize(1)
-                        .subscribe();
+        for (SubscriptionType subscription : ImmutableList.of(SubscriptionType.Exclusive,
+                SubscriptionType.Failover)) {
+            String inputTopicName = topicNamePrefix + subscription.name() + "-input-" + enableBatching;
+            String outputTopicName = topicNamePrefix + subscription.name() + "-output-" + enableBatching;
+            String subscriptionName = subscriptionNamePrefix + subscription.name();
+            @Cleanup
+            org.apache.pulsar.client.api.Consumer<String> inputConsumer = pulsarClient.newConsumer(Schema.STRING)
+                    .topic(inputTopicName).subscriptionName(subscriptionName)
+                    .subscriptionType(subscription)
+                    .receiverQueueSize(totalProducedMessage)
+                    .ackTimeout(1000, TimeUnit.MILLISECONDS)
+                    .negativeAckRedeliveryDelay(0, TimeUnit.SECONDS)
+                    .acknowledgmentGroupTime(0, TimeUnit.SECONDS)
+                    .maxAcknowledgmentGroupSize(1)
+                    .subscribe();
+            @Cleanup
+            org.apache.pulsar.client.api.Consumer<String> outputConsumer = pulsarClient.newConsumer(Schema.STRING)
+                    .topic(outputTopicName).subscriptionName(subscriptionName)
+                    .subscriptionType(subscription)
+                    .receiverQueueSize(totalProducedMessage)
+                    .ackTimeout(1000, TimeUnit.MILLISECONDS)
+                    .negativeAckRedeliveryDelay(0, TimeUnit.SECONDS)
+                    .acknowledgmentGroupTime(0, TimeUnit.SECONDS)
+                    .maxAcknowledgmentGroupSize(1)
+                    .subscribe();
 
-                @Cleanup
-                Producer<String> inputProducer =
-                        pulsarClient.newProducer(Schema.STRING).enableBatching(enableBatching).topic(inputTopicName).create();
+            @Cleanup
+            Producer<String> inputProducer =
+                    pulsarClient.newProducer(Schema.STRING).enableBatching(enableBatching).topic(inputTopicName)
+                            .create();
 
-                @Cleanup
-                Producer<String> outputProducer =
-                        pulsarClient.newProducer(Schema.STRING).enableBatching(enableBatching).topic(outputTopicName).create();
+            @Cleanup
+            Producer<String> outputProducer =
+                    pulsarClient.newProducer(Schema.STRING).enableBatching(enableBatching).topic(outputTopicName)
+                            .create();
 
-                for (int i = 0; i < totalProducedMessage; ++i) {
-                    inputProducer.sendAsync(Integer.toString(i));
-                }
-
-                // 1) check unacked message for inputTopic before transaction
-                checkUnackedMessage(inputTopicName, subscriptionName, totalProducedMessage);
-
-                Transaction trn =
-                        pulsarClient.newTransaction().withTransactionTimeout(10, TimeUnit.SECONDS).build().get();
-
-                // 2) check unacked message after transaction committed
-                for (int i = 0; i < totalProducedMessage; ++i) {
-                    Message<String> msg = inputConsumer.receive(1, TimeUnit.SECONDS);
-                    if (Objects.isNull(msg)) {
-                        Assert.fail("Expected message not received");
-                    }
-                    outputProducer.newMessage(trn).value(msg.getValue()).sendAsync();
-                    inputConsumer.acknowledgeAsync(msg.getMessageId(), trn);
-                }
-                trn.commit().get();
-
-                checkUnackedMessage(inputTopicName, subscriptionName, 0);
-                checkUnackedMessage(outputTopicName, subscriptionName, totalProducedMessage);
-
-                // 3) check unacked message after transaction aborted
-                trn = pulsarClient.newTransaction().withTransactionTimeout(10, TimeUnit.SECONDS).build().get();
-                for (int i = 0; i < totalProducedMessage; ++i) {
-                    Message<String> msg = outputConsumer.receive(1, TimeUnit.SECONDS);
-                    if (Objects.isNull(msg)) {
-                        Assert.fail("Expected message not received");
-                    }
-                    outputConsumer.acknowledgeAsync(msg.getMessageId(), trn);
-                }
-
-                trn.abort().get();
-                checkUnackedMessage(outputTopicName, subscriptionName, totalProducedMessage);
-
-                // 4) check unacked message after transaction commit
-                trn = pulsarClient.newTransaction().withTransactionTimeout(10, TimeUnit.SECONDS).build().get();
-                for (int i = 0; i < totalProducedMessage; ++i) {
-                    Message<String> msg = outputConsumer.receive(1, TimeUnit.SECONDS);
-                    if (Objects.isNull(msg)) {
-                        Assert.fail("Expected message not received");
-                    }
-                    outputConsumer.acknowledgeAsync(msg.getMessageId(), trn);
-                }
-
-                trn.commit().get();
-                checkUnackedMessage(outputTopicName, subscriptionName, 0);
+            for (int i = 0; i < totalProducedMessage; ++i) {
+                inputProducer.sendAsync(Integer.toString(i));
             }
+
+            // 1) check unacked message for inputTopic before transaction
+            checkUnackedMessage(inputTopicName, subscriptionName, totalProducedMessage);
+
+            Transaction trn =
+                    pulsarClient.newTransaction().withTransactionTimeout(10, TimeUnit.SECONDS).build().get();
+
+            // 2) check unacked message after transaction committed
+            for (int i = 0; i < totalProducedMessage; ++i) {
+                Message<String> msg = inputConsumer.receive(1, TimeUnit.SECONDS);
+                if (Objects.isNull(msg)) {
+                    Assert.fail("Expected message not received");
+                }
+                outputProducer.newMessage(trn).value(msg.getValue()).sendAsync();
+                inputConsumer.acknowledgeAsync(msg.getMessageId(), trn);
+            }
+            trn.commit().get();
+
+            checkUnackedMessage(inputTopicName, subscriptionName, 0);
+            checkUnackedMessage(outputTopicName, subscriptionName, totalProducedMessage);
+
+            // 3) check unacked message after transaction aborted
+            trn = pulsarClient.newTransaction().withTransactionTimeout(10, TimeUnit.SECONDS).build().get();
+            for (int i = 0; i < totalProducedMessage; ++i) {
+                Message<String> msg = outputConsumer.receive(1, TimeUnit.SECONDS);
+                if (Objects.isNull(msg)) {
+                    Assert.fail("Expected message not received");
+                }
+                outputConsumer.acknowledgeAsync(msg.getMessageId(), trn);
+            }
+
+            trn.abort().get();
+            checkUnackedMessage(outputTopicName, subscriptionName, totalProducedMessage);
+
+            // 4) check unacked message after transaction commit
+            trn = pulsarClient.newTransaction().withTransactionTimeout(10, TimeUnit.SECONDS).build().get();
+            for (int i = 0; i < totalProducedMessage; ++i) {
+                Message<String> msg = outputConsumer.receive(1, TimeUnit.SECONDS);
+                if (Objects.isNull(msg)) {
+                    Assert.fail("Expected message not received");
+                }
+                outputConsumer.acknowledgeAsync(msg.getMessageId(), trn);
+            }
+
+            trn.commit().get();
+            checkUnackedMessage(outputTopicName, subscriptionName, 0);
         }
     }
 
@@ -349,7 +358,8 @@ public class PersistentDispatcherSingleActiveConsumerTest extends ProducerConsum
     private void checkUnackedMessage(String topicName, String subscriptionName, int expectedUnackedMessage) {
         Awaitility.await().atMost(5, TimeUnit.SECONDS).pollInterval(500, TimeUnit.MILLISECONDS).untilAsserted(() -> {
             TopicStats topicStats = admin.topics().getStats(topicName);
-            assertThat(topicStats.getSubscriptions().get(subscriptionName).getUnackedMessages()).isEqualTo(expectedUnackedMessage);
+            assertThat(topicStats.getSubscriptions().get(subscriptionName).getUnackedMessages()).isEqualTo(
+                    expectedUnackedMessage);
         });
     }
 

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/persistent/PersistentDispatcherSingleActiveConsumerTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/persistent/PersistentDispatcherSingleActiveConsumerTest.java
@@ -19,8 +19,8 @@
 package org.apache.pulsar.broker.service.persistent;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import com.google.common.collect.ImmutableList;
 import com.google.common.collect.Sets;
+import java.util.List;
 import java.util.Objects;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicInteger;
@@ -172,8 +172,7 @@ public class PersistentDispatcherSingleActiveConsumerTest extends ProducerConsum
         // we will check unacked messages every 20 messages
         int checkStep = 20;
 
-        for (SubscriptionType subscription : ImmutableList.of(SubscriptionType.Exclusive,
-                SubscriptionType.Failover)) {
+        for (SubscriptionType subscription : List.of(SubscriptionType.Exclusive, SubscriptionType.Failover)) {
             String topicName = topicNamePrefix + subscription.name() + "-" + enableBatching;
             String subscriptionName = subscriptionNamePrefix + subscription.name();
             @Cleanup
@@ -266,8 +265,7 @@ public class PersistentDispatcherSingleActiveConsumerTest extends ProducerConsum
                 .statsInterval(0, TimeUnit.SECONDS)
                 .build();
 
-        for (SubscriptionType subscription : ImmutableList.of(SubscriptionType.Exclusive,
-                SubscriptionType.Failover)) {
+        for (SubscriptionType subscription : List.of(SubscriptionType.Exclusive, SubscriptionType.Failover)) {
             String inputTopicName = topicNamePrefix + subscription.name() + "-input-" + enableBatching;
             String outputTopicName = topicNamePrefix + subscription.name() + "-output-" + enableBatching;
             String subscriptionName = subscriptionNamePrefix + subscription.name();

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/persistent/PersistentDispatcherSingleActiveConsumerTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/persistent/PersistentDispatcherSingleActiveConsumerTest.java
@@ -156,10 +156,10 @@ public class PersistentDispatcherSingleActiveConsumerTest extends ProducerConsum
                     .subscribe();
 
             @Cleanup
-            Producer<String> producer = pulsarClient.newProducer(Schema.STRING).topic(topicName).create();
+            Producer<String> producer = pulsarClient.newProducer(Schema.STRING).enableBatching(true).topic(topicName).create();
 
             for (int i = 0; i < totalProducedMessage; ++i) {
-                producer.send(Integer.toString(i));
+                producer.sendAsync(Integer.toString(i));
             }
 
             // 1) check unacked message at begin
@@ -182,7 +182,7 @@ public class PersistentDispatcherSingleActiveConsumerTest extends ProducerConsum
 
             // 4) test negative ack
             for (int i = 0; i < totalProducedMessage; ++i) {
-                producer.send(Integer.toString(i));
+                producer.sendAsync(Integer.toString(i));
             }
             Message<String> msg = null;
             checkUnackedMessage(topicName, subscriptionName, totalProducedMessage);

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/persistent/PersistentDispatcherSingleActiveConsumerTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/persistent/PersistentDispatcherSingleActiveConsumerTest.java
@@ -20,6 +20,7 @@ package org.apache.pulsar.broker.service.persistent;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import com.google.common.collect.ImmutableList;
+import com.google.common.collect.Sets;
 import java.util.Objects;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicInteger;
@@ -29,14 +30,21 @@ import org.apache.bookkeeper.mledger.ManagedCursor;
 import org.apache.bookkeeper.mledger.ManagedLedgerException;
 import org.apache.bookkeeper.mledger.impl.ManagedCursorImpl;
 import org.apache.pulsar.broker.BrokerTestUtil;
+import org.apache.pulsar.broker.ServiceConfiguration;
 import org.apache.pulsar.broker.service.Consumer;
 import org.apache.pulsar.broker.service.Subscription;
 import org.apache.pulsar.client.api.Message;
 import org.apache.pulsar.client.api.Producer;
 import org.apache.pulsar.client.api.ProducerConsumerBase;
+import org.apache.pulsar.client.api.PulsarClient;
 import org.apache.pulsar.client.api.Schema;
 import org.apache.pulsar.client.api.SubscriptionType;
+import org.apache.pulsar.client.api.transaction.Transaction;
 import org.apache.pulsar.common.api.proto.CommandSubscribe;
+import org.apache.pulsar.common.naming.NamespaceName;
+import org.apache.pulsar.common.naming.SystemTopicNames;
+import org.apache.pulsar.common.partition.PartitionedTopicMetadata;
+import org.apache.pulsar.common.policies.data.TenantInfoImpl;
 import org.apache.pulsar.common.policies.data.TopicStats;
 import org.awaitility.Awaitility;
 import org.mockito.Mockito;
@@ -51,8 +59,19 @@ public class PersistentDispatcherSingleActiveConsumerTest extends ProducerConsum
     @BeforeClass(alwaysRun = true)
     @Override
     protected void setup() throws Exception {
-        super.internalSetup();
+        ServiceConfiguration serviceConfiguration = getDefaultConf();
+//        serviceConfiguration.setTopicLevelPoliciesEnabled(false);
+        serviceConfiguration.setTransactionCoordinatorEnabled(true);
+        super.internalSetup(serviceConfiguration);
         super.producerBaseSetup();
+
+        // Setup namespaces
+        admin.tenants().createTenant(NamespaceName.SYSTEM_NAMESPACE.getTenant(),
+                new TenantInfoImpl(Sets.newHashSet("appid1"), Sets.newHashSet("test")));
+        admin.namespaces().createNamespace(NamespaceName.SYSTEM_NAMESPACE.toString());
+        pulsar.getPulsarResources().getNamespaceResources().getPartitionedTopicResources()
+                .createPartitionedTopic(SystemTopicNames.TRANSACTION_COORDINATOR_ASSIGN,
+                        new PartitionedTopicMetadata(1));
     }
 
     @AfterClass(alwaysRun = true)
@@ -135,8 +154,9 @@ public class PersistentDispatcherSingleActiveConsumerTest extends ProducerConsum
 
     @Test
     public void testUnackedMessages() throws Exception {
-        String topicNamePrefix = "testUnackedMessages-" + System.currentTimeMillis();
-        String subscriptionNamePrefix = "testUnackedMessages-sub-";
+        long timeMillis = System.currentTimeMillis();
+        String topicNamePrefix = "testUnackedMessages-" + timeMillis;
+        String subscriptionNamePrefix = "testUnackedMessages-sub-" + timeMillis;
         int totalProducedMessage = 100;
         // we will check unacked messages every 20 messages
         int checkStep = 20;
@@ -216,6 +236,109 @@ public class PersistentDispatcherSingleActiveConsumerTest extends ProducerConsum
             checkUnackedMessage(topicName, subscriptionName, totalProducedMessage);
         }
     }
+
+    @Test
+    public void testUnackedMessagesWithTransaction() throws Exception {
+        String topicNamePrefix = "testUnackedMessagesWithTrn-" + System.currentTimeMillis();
+        String subscriptionNamePrefix = "testUnackedMessagesWithTrn-sub-";
+        int totalProducedMessage = 100;
+
+        @Cleanup
+        PulsarClient pulsarClient = PulsarClient.builder()
+                .enableTransaction(true)
+                .serviceUrl(pulsar.getBrokerServiceUrl())
+                .connectionsPerBroker(100)
+                .statsInterval(0, TimeUnit.SECONDS)
+                .build();
+
+        for (boolean enableBatching: ImmutableList.of(false, true)) {
+            for (SubscriptionType subscription : ImmutableList.of(SubscriptionType.Exclusive,
+                    SubscriptionType.Failover)) {
+                String inputTopicName = topicNamePrefix + subscription.name() + "-input-" + enableBatching;
+                String outputTopicName = topicNamePrefix + subscription.name() + "-output-"+ enableBatching;
+                String subscriptionName = subscriptionNamePrefix + subscription.name();
+                @Cleanup
+                org.apache.pulsar.client.api.Consumer<String> inputConsumer = pulsarClient.newConsumer(Schema.STRING)
+                        .topic(inputTopicName).subscriptionName(subscriptionName)
+                        .subscriptionType(subscription)
+                        .receiverQueueSize(totalProducedMessage)
+                        .ackTimeout(1000, TimeUnit.MILLISECONDS)
+                        .negativeAckRedeliveryDelay(0, TimeUnit.SECONDS)
+                        .acknowledgmentGroupTime(0, TimeUnit.SECONDS)
+                        .maxAcknowledgmentGroupSize(1)
+                        .subscribe();
+                @Cleanup
+                org.apache.pulsar.client.api.Consumer<String> outputConsumer = pulsarClient.newConsumer(Schema.STRING)
+                        .topic(outputTopicName).subscriptionName(subscriptionName)
+                        .subscriptionType(subscription)
+                        .receiverQueueSize(totalProducedMessage)
+                        .ackTimeout(1000, TimeUnit.MILLISECONDS)
+                        .negativeAckRedeliveryDelay(0, TimeUnit.SECONDS)
+                        .acknowledgmentGroupTime(0, TimeUnit.SECONDS)
+                        .maxAcknowledgmentGroupSize(1)
+                        .subscribe();
+
+                @Cleanup
+                Producer<String> inputProducer =
+                        pulsarClient.newProducer(Schema.STRING).enableBatching(enableBatching).topic(inputTopicName).create();
+
+                @Cleanup
+                Producer<String> outputProducer =
+                        pulsarClient.newProducer(Schema.STRING).enableBatching(enableBatching).topic(outputTopicName).create();
+
+                for (int i = 0; i < totalProducedMessage; ++i) {
+                    inputProducer.sendAsync(Integer.toString(i));
+                }
+
+                // 1) check unacked message for inputTopic before transaction
+                checkUnackedMessage(inputTopicName, subscriptionName, totalProducedMessage);
+
+                Transaction trn =
+                        pulsarClient.newTransaction().withTransactionTimeout(10, TimeUnit.SECONDS).build().get();
+
+                // 2) check unacked message after transaction committed
+                for (int i = 0; i < totalProducedMessage; ++i) {
+                    Message<String> msg = inputConsumer.receive(1, TimeUnit.SECONDS);
+                    if (Objects.isNull(msg)) {
+                        Assert.fail("Expected message not received");
+                    }
+                    outputProducer.newMessage(trn).value(msg.getValue()).sendAsync();
+                    inputConsumer.acknowledgeAsync(msg.getMessageId(), trn);
+                }
+                trn.commit().get();
+
+                checkUnackedMessage(inputTopicName, subscriptionName, 0);
+                checkUnackedMessage(outputTopicName, subscriptionName, totalProducedMessage);
+
+                // 3) check unacked message after transaction aborted
+                trn = pulsarClient.newTransaction().withTransactionTimeout(10, TimeUnit.SECONDS).build().get();
+                for (int i = 0; i < totalProducedMessage; ++i) {
+                    Message<String> msg = outputConsumer.receive(1, TimeUnit.SECONDS);
+                    if (Objects.isNull(msg)) {
+                        Assert.fail("Expected message not received");
+                    }
+                    outputConsumer.acknowledgeAsync(msg.getMessageId(), trn);
+                }
+
+                trn.abort().get();
+                checkUnackedMessage(outputTopicName, subscriptionName, totalProducedMessage);
+
+                // 4) check unacked message after transaction commit
+                trn = pulsarClient.newTransaction().withTransactionTimeout(10, TimeUnit.SECONDS).build().get();
+                for (int i = 0; i < totalProducedMessage; ++i) {
+                    Message<String> msg = outputConsumer.receive(1, TimeUnit.SECONDS);
+                    if (Objects.isNull(msg)) {
+                        Assert.fail("Expected message not received");
+                    }
+                    outputConsumer.acknowledgeAsync(msg.getMessageId(), trn);
+                }
+
+                trn.commit().get();
+                checkUnackedMessage(outputTopicName, subscriptionName, 0);
+            }
+        }
+    }
+
 
     private void checkUnackedMessage(String topicName, String subscriptionName, int expectedUnackedMessage) {
         Awaitility.await().atMost(5, TimeUnit.SECONDS).pollInterval(500, TimeUnit.MILLISECONDS).untilAsserted(() -> {


### PR DESCRIPTION
<!--
### Contribution Checklist
  
  - PR title format should be *[type][component] summary*. For details, see *[Guideline - Pulsar PR Naming Convention](https://pulsar.apache.org/contribute/develop-semantic-title/)*. 

  - Fill out the template below to describe the changes contributed by the pull request. That will give reviewers the context they need to do the review.
  
  - Each pull request should address only one issue, not mix up code from multiple issues.
  
  - Each commit in the pull request has a meaningful commit message

  - Once all items of the checklist are addressed, remove the above text and this checklist, leaving only the filled out template below.
-->

<!-- Either this PR fixes an issue, -->

Fixes https://github.com/apache/pulsar/issues/24159

<!-- or this PR is one task of an issue -->

Main Issue: https://github.com/apache/pulsar/issues/24159

<!-- If the PR belongs to a PIP, please add the PIP link here -->


### Motivation

<!-- Explain here the context, and why you're making that change. What is the problem you're trying to solve. -->

1. I have tried to fix the issue by https://github.com/apache/pulsar/pull/24376. However, it's not work when consumer use cumulative ack mode or batching mode. So I want to fix it further.
2. I have found another issue that flowcontrol of exclusive or failover consumer is not work. Since the issues are highly correlated, I want to fix them at the same time. 

<details>
<summary>We can reproduce flow control issue by this unit test</summary>

```
@Test(timeOut = 30000)
    public void testMaxUnackedMessagesOnExclusiveConsumer() throws Exception {
        final String topicName = testTopic + System.currentTimeMillis();
        final String subscriberName = "test-sub-exclusive" + System.currentTimeMillis();
        final int unackMsgAllowed = 100;
        final int receiverQueueSize = 10;
        final int totalProducedMsgs = 300;

        ConsumerBuilder<String> consumerBuilder = pulsarClient.newConsumer(Schema.STRING).topic(topicName)
                .subscriptionName(subscriberName).receiverQueueSize(receiverQueueSize)
                .ackTimeout(1, TimeUnit.MINUTES)
                .subscriptionType(SubscriptionType.Exclusive);
        @Cleanup
        Consumer<String> consumer = consumerBuilder.subscribe();
        // 1) Produced Messages
        @Cleanup
        Producer<String> producer = pulsarClient.newProducer(Schema.STRING).topic(topicName).create();
        for (int i = 0; i < totalProducedMsgs; i++) {
            String message = "my-message-" + i;
            producer.send(message);
        }
        // 2) Unlimited, so all messages can be consumed
        int count = 0;
        List<Message<String>> list = new ArrayList<>(totalProducedMsgs);
        for (int i = 0; i < totalProducedMsgs; i++) {
            Message<String> message = consumer.receive(1, TimeUnit.SECONDS);
            if (message == null) {
                break;
            }
            count++;
            list.add(message);
        }
        assertEquals(count, totalProducedMsgs);
        list.forEach(message -> {
            try {
                consumer.acknowledge(message);
            } catch (PulsarClientException e) {
            }
        });
        // 3) Set restrictions, so only part of the data can be consumed
        waitCacheInit(topicName);
        admin.topics().setMaxUnackedMessagesOnConsumer(topicName, unackMsgAllowed);
        Awaitility.await().untilAsserted(()
                -> assertNotNull(admin.topics().getMaxUnackedMessagesOnConsumer(topicName)));
        assertEquals(admin.topics().getMaxUnackedMessagesOnConsumer(topicName).intValue(), unackMsgAllowed);
        // 4) consumer can only consume 100 messages
        for (int i = 0; i < totalProducedMsgs; i++) {
            String message = "my-message-" + i;
            producer.send(message);
        }
        int consumerCounter = 0;
        Message<String> message = null;
        for (int i = 0; i < totalProducedMsgs; i++) {
            try {
                Message<String> msg = consumer.receive(500, TimeUnit.MILLISECONDS);
                if (msg == null) {
                    break;
                }
                message = msg;
                ++consumerCounter;
            } catch (PulsarClientException e) {
                break;
            }
        }
        assertEquals(consumerCounter, unackMsgAllowed);
        consumer.acknowledgeCumulative(message.getMessageId());
        consumerCounter = 0;
        for (int i = 0; i < totalProducedMsgs - unackMsgAllowed; i++) {
            try {
                message = consumer.receive(500, TimeUnit.MILLISECONDS);
                if (message == null) {
                    break;
                }
                ++consumerCounter;
            } catch (PulsarClientException e) {
                break;
            }
        }
        assertEquals(consumerCounter, unackMsgAllowed);
    }
```
</details>


### Modifications

We use the `pendingAcks` in `Consumer` to track unacked message for exlusive or failover subscription. We will also fix the flow control issue by the `pendingAcks`. However, `pendingAcks` is limited to individualAckMode before. So we will remove the limitation in all place.

<!-- Describe the modifications you've done. -->

### Verifying this change

- [X] Make sure that the change passes the CI checks.

This change is already covered by existing tests, such as *(please describe tests)*.
* MaxUnackedMessagesTest#testMaxUnackedMessagesOnConsumer

This change added tests and can be verified as follows:
* MaxUnackedMessagesTest#testMaxUnackedMessagesOnExclusiveConsumer
* MaxUnackedMessagesTest#testMaxUnackedMessagesOnFailOverConsumer
* PersistentDispatcherSingleActiveConsumerTest#testUnackedMessages

### Does this pull request potentially affect one of the following parts:

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

*If the box was checked, please highlight the changes*

- [ ] Dependencies (add or upgrade a dependency)
- [ ] The public API
- [ ] The schema
- [ ] The default values of configurations
- [ ] The threading model
- [ ] The binary protocol
- [ ] The REST endpoints
- [ ] The admin CLI options
- [ ] The metrics
- [ ] Anything that affects deployment

### Documentation

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

- [ ] `doc` <!-- Your PR contains doc changes. -->
- [ ] `doc-required` <!-- Your PR changes impact docs and you will update later -->
- [X] `doc-not-needed` <!-- Your PR changes do not impact docs -->
- [ ] `doc-complete` <!-- Docs have been already added -->

### Matching PR in forked repository

PR in forked repository: <!-- ENTER URL HERE -->

<!--
After opening this PR, the build in apache/pulsar will fail and instructions will
be provided for opening a PR in the PR author's forked repository.

apache/pulsar pull requests should be first tested in your own fork since the 
apache/pulsar CI based on GitHub Actions has constrained resources and quota.
GitHub Actions provides separate quota for pull requests that are executed in 
a forked repository.

The tests will be run in the forked repository until all PR review comments have
been handled, the tests pass and the PR is approved by a reviewer.
-->
