### PR TITLE
[fix][client] All chunkMessageIds sent to broker for redelivery

### DIFF
--- a/pulsar-client/src/main/java/org/apache/pulsar/client/impl/ConsumerImpl.java
+++ b/pulsar-client/src/main/java/org/apache/pulsar/client/impl/ConsumerImpl.java
@@ -1508,7 +1508,6 @@ public class ConsumerImpl<T> extends ConsumerBase<T> implements ConnectionHandle
         // and return undecrypted payload
         if (isMessageUndecryptable || (numMessages == 1 && !msgMetadata.hasNumMessagesInBatch())) {
 
-            // right now, chunked messages are only supported by non-shared subscription
             if (isChunkedMessage) {
                 uncompressedPayload = processMessageChunk(uncompressedPayload, msgMetadata, msgId, messageId, cnx);
                 if (uncompressedPayload == null) {

--- a/pulsar-client/src/main/java/org/apache/pulsar/client/impl/NegativeAcksTracker.java
+++ b/pulsar-client/src/main/java/org/apache/pulsar/client/impl/NegativeAcksTracker.java
@@ -158,7 +158,7 @@ class NegativeAcksTracker implements Closeable {
     private synchronized void add(MessageId messageId, int redeliveryCount) {
         if (messageId instanceof TraceableMessageId) {
             Span span = ((TraceableMessageId) messageId).getTracingSpan();
-            if (span != null) {
+            if (span != null || messageId instanceof ChunkMessageIdImpl) {
                 MessageIdAdv msgId = (MessageIdAdv) messageId;
                 nackedMessageIds.computeIfAbsent(msgId.getLedgerId(), k -> new Long2ObjectOpenHashMap<>())
                         .put(msgId.getEntryId(), messageId);


### PR DESCRIPTION
<!--
### Contribution Checklist
  
  - PR title format should be *[type][component] summary*. For details, see *[Guideline - Pulsar PR Naming Convention](https://pulsar.apache.org/contribute/develop-semantic-title/)*. 

  - Fill out the template below to describe the changes contributed by the pull request. That will give reviewers the context they need to do the review.
  
  - Each pull request should address only one issue, not mix up code from multiple issues.
  
  - Each commit in the pull request has a meaningful commit message

  - Once all items of the checklist are addressed, remove the above text and this checklist, leaving only the filled out template below.
-->

<!-- Either this PR fixes an issue, -->

Fixes #25220


### Motivation

<!-- Explain here the context, and why you're making that change. What is the problem you're trying to solve. -->

There is an issue that chunked message cannot be redeliveryed for shared subscription mode. The client should send all chunk message ids to broker for redelivery but it hasn't. It only send the last chunk messageId and that's the root cause of this issue.

The problematic code path​​ is that:
```
    NegativeAcksTracker#triggerRedelivery
        UnAckedMessageTracker#addChunkedMessageIdsAndRemoveFromSequenceMap
```
In `addChunkedMessageIdsAndRemoveFromSequenceMap` method, all chunk messageIds should be fetched from `consumerBase.unAckedChunkedMessageIdSequenceMap` but it found nothing there. Actually, `unAckedChunkedMessageIdSequenceMap` has recorded the value by [key](https://github.com/apache/pulsar/blob/master/pulsar-client/src/main/java/org/apache/pulsar/client/impl/ConsumerImpl.java#L1527-L1532) which has type of `ChunkMessageIdImpl`.  `ChunkMessageIdImpl` has a different hashcode from `MessageIdImpl`. That's why we found nothing there. 

I have noticed that there is a `nackedMessageIds` map in `NegativeAcksTracker`. And it's convenient to record the origin messageId by `nackedMessageIds` which has a type of `ChunkMessageIdImpl`. 

### Modifications

<!-- Describe the modifications you've done. -->

Record the origin messageId by the map `nackedMessageIds` in `NegativeAcksTracker`

### Verifying this change

- [ ] Make sure that the change passes the CI checks.


This change added tests and can be verified as follows:

```java
MessageChunkingSharedTest#testNegativeAckChunkedMessage
```

### Does this pull request potentially affect one of the following parts:

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

*If the box was checked, please highlight the changes*

- [ ] Dependencies (add or upgrade a dependency)
- [ ] The public API
- [ ] The schema
- [ ] The default values of configurations
- [ ] The threading model
- [ ] The binary protocol
- [ ] The REST endpoints
- [ ] The admin CLI options
- [ ] The metrics
- [ ] Anything that affects deployment

### Documentation

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

- [ ] `doc` <!-- Your PR contains doc changes. -->
- [ ] `doc-required` <!-- Your PR changes impact docs and you will update later -->
- [x] `doc-not-needed` <!-- Your PR changes do not impact docs -->
- [ ] `doc-complete` <!-- Docs have been already added -->

### Matching PR in forked repository

PR in forked repository: <!-- ENTER URL HERE -->
https://github.com/berg223/pulsar/pull/4
<!--
After opening this PR, the build in apache/pulsar will fail and instructions will
be provided for opening a PR in the PR author's forked repository.

apache/pulsar pull requests should be first tested in your own fork since the 
apache/pulsar CI based on GitHub Actions has constrained resources and quota.
GitHub Actions provides separate quota for pull requests that are executed in 
a forked repository.

The tests will be run in the forked repository until all PR review comments have
been handled, the tests pass and the PR is approved by a reviewer.
-->
